### PR TITLE
feat: imagePullSecrets and Container Args

### DIFF
--- a/mirrord-operator/templates/deployment.yaml
+++ b/mirrord-operator/templates/deployment.yaml
@@ -14,6 +14,9 @@ spec:
       labels:
         app: mirrord-operator
     spec:
+      {{- if .Values.operator.imagePullSecrets }}
+      {{- toYaml .Values.operator.imagePullSecrets }}
+      {{- else }}
       containers:
       - env:
         - name: RUST_LOG
@@ -40,6 +43,9 @@ spec:
         {{- end }}
         image: {{ .Values.operator.image }}:{{ .Chart.AppVersion }}
         imagePullPolicy: IfNotPresent
+        {{- if .Values.operator.containerArgs }}
+        {{- toYaml .Values.operator.containerArgs }}
+        {{- else }}
         livenessProbe:
           httpGet:
             path: /health

--- a/mirrord-operator/templates/deployment.yaml
+++ b/mirrord-operator/templates/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       {{- if .Values.operator.imagePullSecrets }}
       {{- toYaml .Values.operator.imagePullSecrets }}
-      {{- else }}
+      {{- end }}
       containers:
       - env:
         - name: RUST_LOG
@@ -45,7 +45,7 @@ spec:
         imagePullPolicy: IfNotPresent
         {{- if .Values.operator.containerArgs }}
         {{- toYaml .Values.operator.containerArgs }}
-        {{- else }}
+        {{- end }}
         livenessProbe:
           httpGet:
             path: /health

--- a/mirrord-operator/values.yaml
+++ b/mirrord-operator/values.yaml
@@ -6,6 +6,11 @@ namespace: mirrord
 
 operator:
   image: ghcr.io/metalbear-co/operator
+  # imagePullSecrets:
+  #   - name: value
+  # containerArgs:
+  #   - '--agent-config'
+  #   - '{"image_pull_secrets":[{"name":"docker"}]}'
 
 license:
   key: ""


### PR DESCRIPTION
Add the ability to set `imagePullSecrets` and container args for the Mirrord Operator Deployment.