### PR TITLE
Add `eks.amazonaws.com/role-arn` annotation

### DIFF
--- a/mirrord-operator/README.md
+++ b/mirrord-operator/README.md
@@ -65,8 +65,8 @@ cat >trust-relationship.json <<EOF
       "Action": "sts:AssumeRoleWithWebIdentity",
       "Condition": {
         "StringEquals": {
-          "$oidc_provider:aud": "sts.amazonaws.com",
-          "$oidc_provider:sub": "system:serviceaccount:$namespace:$service_account"
+          "${oidc_provider}:aud": "sts.amazonaws.com",
+          "${oidc_provider}:sub": "system:serviceaccount:$namespace:$service_account"
         }
       }
     }

--- a/mirrord-operator/README.md
+++ b/mirrord-operator/README.md
@@ -20,3 +20,65 @@ If you have a certificate license (usually part of Enterprise offering) you can:
         license.pem: LICENSE_CONTENT
     ```
     then reference it using `license.pemRef` in `values.yaml`
+
+
+### SQS queue splitting
+
+When using EKS we need to allow the operator to modify `sqs` queues
+
+```bash
+export account_id=$(aws sts get-caller-identity --query "Account" --output text)
+
+cat >mirrord-operator-policy.json <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "sqs:*"
+            ],
+            "Resource": [
+                "arn:aws:sqs:*:$account_id:*"
+            ]
+        }
+    ]
+}
+EOF
+
+aws iam create-policy --policy-name mirrord-operator-policy --policy-document file://mirrord-operator-policy.json
+
+export oidc_provider=$(aws eks describe-cluster --name my-cluster --region $AWS_REGION --query "cluster.identity.oidc.issuer" --output text | sed -e "s/^https:\/\///")
+
+export namespace=mirrord
+export service_account=mirrord-operator
+
+cat >trust-relationship.json <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::$account_id:oidc-provider/$oidc_provider"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "$oidc_provider:aud": "sts.amazonaws.com",
+          "$oidc_provider:sub": "system:serviceaccount:$namespace:$service_account"
+        }
+      }
+    }
+  ]
+}
+EOF
+
+aws iam create-role --role-name mirrord-operator-role --assume-role-policy-document file://trust-relationship.json --description "Role for SQS splitting for mirrord-operator"
+
+aws iam attach-role-policy --role-name mirrord-operator-role --policy-arn=arn:aws:iam::$account_id:policy/mirrord-operator-role
+
+```
+*[aws docs referance](https://docs.aws.amazon.com/eks/latest/userguide/associate-service-account-role.html)*
+
+And setting the `sa.roleArn` value in `values.yaml` or via `--set sa.roleArn=arn:aws:iam::$account_id:role/mirrord-operator-role`

--- a/mirrord-operator/templates/service-account.yaml
+++ b/mirrord-operator/templates/service-account.yaml
@@ -1,6 +1,10 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  {{- if .Values.sa.roleArn }}
+  annotations:
+    eks.amazonaws.com/role-arn: {{ .Values.sa.roleArn }}
+  {{- end }}
   labels:
     app: mirrord-operator
   name: {{ .Values.sa.name }}

--- a/mirrord-operator/values.yaml
+++ b/mirrord-operator/values.yaml
@@ -55,6 +55,9 @@ service:
 
 sa:
   name: mirrord-operator
+  
+  ## aws role arn to annotate for eks iam assumption
+  # roleArn: arn:aws:iam::111122223333:role/my-role
 
 tls:
   secret: mirrord-operator-tls

--- a/mirrord-operator/values.yaml
+++ b/mirrord-operator/values.yaml
@@ -57,7 +57,7 @@ sa:
   name: mirrord-operator
   
   ## aws role arn to annotate for eks iam assumption
-  # roleArn: arn:aws:iam::111122223333:role/my-role
+  # roleArn: arn:aws:iam::111122223333:role/mirrord-operator-role
 
 tls:
   secret: mirrord-operator-tls


### PR DESCRIPTION
Add `sa.roleArn` value that maps to `eks.amazonaws.com/role-arn` annotation on service account.

relevant for metalbear-co/mirrord#2293.