### PR TITLE
Mention agent json_log in values.yaml.

### DIFF
--- a/mirrord-operator/values.yaml
+++ b/mirrord-operator/values.yaml
@@ -58,6 +58,8 @@ agent:
   ## see possible settings here: https://mirrord.dev/docs/reference/configuration/#root-agent
   extraConfig:
   #  json_log: false
+  #  labels: '{ "user": "meow" }'
+  #  annotations: '{ "cats.io/inject": "enabled" }'
   #  tolerations:
   #    - operator: Exists
   #  privileged: true

--- a/mirrord-operator/values.yaml
+++ b/mirrord-operator/values.yaml
@@ -58,8 +58,8 @@ agent:
   ## see possible settings here: https://mirrord.dev/docs/reference/configuration/#root-agent
   extraConfig:
   #  json_log: false
-  #  labels: '{ "user": "meow" }'
-  #  annotations: '{ "cats.io/inject": "enabled" }'
+  #  labels: { "user": "meow" }
+  #  annotations: { "cats.io/inject": "enabled" }
   #  tolerations:
   #    - operator: Exists
   #  privileged: true

--- a/mirrord-operator/values.yaml
+++ b/mirrord-operator/values.yaml
@@ -51,10 +51,11 @@ agent:
 
   ## use this if you want to add settings that aren't covered by the values.yaml
   ## see possible settings here: https://mirrord.dev/docs/reference/configuration/#root-agent
- extraConfig:
-  #   tolerations:
-  #     - operator: Exists
-  #   privileged: true
+  extraConfig:
+  #  json_log: false
+  #  tolerations:
+  #    - operator: Exists
+  #  privileged: true
 
 
 


### PR DESCRIPTION
- Issue: [#494](https://github.com/metalbear-co/operator/issues/494)

From the issue:

@aviramha 

> When we do it probably would need to support podLabels and podAnnotations for the agent itself

I'm not quite sure what this means?

Also, options passed through `extraConfig` have to be snake case (match the agent config). It failed when I tried setting it to `jsonLog` like the operator value, as it works there due to `jsonLog` being converted into `true`/`false` in the helm thingy.