### PR TITLE
Add option to specify operator deployment tolerations

### DIFF
--- a/mirrord-operator/Chart.yaml
+++ b/mirrord-operator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.6.7
+version: 1.6.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/mirrord-operator/Chart.yaml
+++ b/mirrord-operator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.6.8
+version: 1.7.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/mirrord-operator/templates/deployment.yaml
+++ b/mirrord-operator/templates/deployment.yaml
@@ -37,6 +37,12 @@ spec:
         sysctls:
         - name: net.ipv4.ip_unprivileged_port_start
           value: "443"
+      {{- if .Values.operator.tolerations }}
+      tolerations:
+        {{- range .Values.operator.tolerations }}
+        - {{ toYaml . }}
+        {{- end }}
+      {{- end }}
       containers:
       - env:
         - name: RUST_LOG

--- a/mirrord-operator/values.yaml
+++ b/mirrord-operator/values.yaml
@@ -40,6 +40,13 @@ operator:
     cpu: 200m
     memory: 200Mi
 
+  ## Allow to specify custom tolerations for operator deployment
+  # tolerations:
+  #   - key: "key1"
+  #     operator: "Equal"
+  #     value: "value1"
+  #     effect: "NoSchedule"
+
 agent:
   ## example
   ##

--- a/mirrord-operator/values.yaml
+++ b/mirrord-operator/values.yaml
@@ -40,7 +40,7 @@ operator:
     cpu: 200m
     memory: 200Mi
 
-  ## Allow to specify custom tolerations for operator deployment
+  ## Allow to specify tolerations for operator deployment
   # tolerations:
   #   - key: "key1"
   #     operator: "Equal"


### PR DESCRIPTION
allow to specify tolerations in `values.yaml`
```yaml
operator:
  ...
  tolerations:
    - key: "key1"
      operator: "Equal"
      value: "value1"
      effect: "NoSchedule"
```
