### PR TITLE
add ability to configure operator.port 

### DIFF
--- a/mirrord-operator/Chart.yaml
+++ b/mirrord-operator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.7.2
+version: 1.8.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/mirrord-operator/templates/api-service.yaml
+++ b/mirrord-operator/templates/api-service.yaml
@@ -11,6 +11,6 @@ spec:
   service:
     name: {{ .Values.service.name }}
     namespace: {{ .Values.namespace }}
-    port: 443
+    port: {{ .Values.operator.port }}
   version: v1
   versionPriority: 15

--- a/mirrord-operator/templates/deployment.yaml
+++ b/mirrord-operator/templates/deployment.yaml
@@ -33,10 +33,13 @@ spec:
         - {{ toYaml . }}
         {{- end }}
       {{- end }}
+      {{/* Allow low port using ip_unprivileged_port_start */}}
+      {{- if lt (int .Values.operator.port) 1024 -}}
       securityContext:
         sysctls:
         - name: net.ipv4.ip_unprivileged_port_start
-          value: "443"
+          value: {{ .Values.operator.port | quote}}
+      {{- end }}
       {{- if .Values.operator.tolerations }}
       tolerations:
         {{- range .Values.operator.tolerations }}
@@ -48,7 +51,7 @@ spec:
         - name: RUST_LOG
           value: mirrord=info,operator=info
         - name: OPERATOR_ADDR
-          value: 0.0.0.0:443
+          value: {{ printf "0.0.0.0:%d" (int .Values.operator.port ) }}
         - name: OPERATOR_NAMESPACE
           value: {{ .Values.namespace }}
         - name: OPERATOR_SERVICE_NAME
@@ -100,17 +103,17 @@ spec:
         livenessProbe:
           httpGet:
             path: /health
-            port: 443
+            port: {{ .Values.operator.port }}
             scheme: HTTPS
           periodSeconds: 5
         name: mirrord-operator
         ports:
-        - containerPort: 443
+        - containerPort: {{ .Values.operator.port }}
           name: https
         readinessProbe:
           httpGet:
             path: /health
-            port: 443
+            port: {{ .Values.operator.port }}
             scheme: HTTPS
           periodSeconds: 5
         resources:

--- a/mirrord-operator/templates/service.yaml
+++ b/mirrord-operator/templates/service.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   ports:
   - name: https
-    port: 443
+    port: {{ .Values.operator.port }}
     targetPort: https
   selector:
     app: mirrord-operator

--- a/mirrord-operator/values.yaml
+++ b/mirrord-operator/values.yaml
@@ -47,6 +47,11 @@ operator:
   #     value: "value1"
   #     effect: "NoSchedule"
 
+  # Port for operator to listen on. If you can't listen on 443 due to privilege issues
+  # you can change this to 3000/8443 or whatever you want - just make sure that nodes
+  # can communicate on that port if it doesn't work then.
+  port: 443
+
 agent:
   ## example
   ##


### PR DESCRIPTION
add ability to configure operator.port in case listening on 443 isn't possible (or for any other reason)