### PR TITLE
Fix tolerations parsing

### DIFF
--- a/mirrord-operator/templates/deployment.yaml
+++ b/mirrord-operator/templates/deployment.yaml
@@ -42,9 +42,7 @@ spec:
       {{- end }}
       {{- if .Values.operator.tolerations }}
       tolerations:
-        {{- range .Values.operator.tolerations }}
-        - {{ toYaml . }}
-        {{- end }}
+        {{- toYaml .Values.operator.tolerations | nindent 8 }}
       {{- end }}
       containers:
       - env:


### PR DESCRIPTION
The way the chart parse tolerations doesn't match the example given in your [values file](https://github.com/metalbear-co/charts/blob/main/mirrord-operator/values.yaml#L44). 

This is an easy fix as suggested in this PR.
Also you might have the same issue in other places but I didn't check or need them.


before the fix:
```
      tolerations:
        - effect: NoSchedule
key: kubernetes.azure.com/scalesetpriority
operator: Equal
value: spot
```

after the fix
```
      tolerations:
        - effect: NoSchedule
          key: kubernetes.azure.com/scalesetpriority
          operator: Equal
          value: spot
```
*also validated with 2 tolerations and with zero tolerations
```
      tolerations:
        - effect: NoSchedule
          key: kubernetes.azure.com/scalesetpriority
          operator: Equal
          value: spot
        - effect: NoSchedule
          key: test
          operator: Equal
          value: spot
```          