### PR TITLE
Add operator permissions for argocd appications

### DIFF
--- a/mirrord-operator/Chart.yaml
+++ b/mirrord-operator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.10.4
+version: 1.10.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/mirrord-operator/templates/cluster-role.yaml
+++ b/mirrord-operator/templates/cluster-role.yaml
@@ -139,6 +139,16 @@ rules:
   - list
   - watch
 {{- end }}
+{{- if .Values.operator.applicationPauseAutoSync }}
+- apiGroups:
+  - argoproj.io
+  resources:
+  - applications
+  verbs:
+  - list
+  - get
+  - patch
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/mirrord-operator/templates/deployment.yaml
+++ b/mirrord-operator/templates/deployment.yaml
@@ -72,6 +72,10 @@ spec:
           value: {{ .Values.operator.sqsSplitting | ternary "true" "false" | quote }}
         - name: OPERATOR_KAFKA_SPLITTING
           value: {{ .Values.operator.kafkaSplitting | ternary "true" "false" | quote }}
+        {{- if .Values.operator.applicationPauseAutoSync }}
+        - name: OPERATOR_APPLICATION_PAUSE_AUTO_SYNC
+          value: "true"
+        {{- end }}
         - name: OPERATOR_JSON_LOG
           value: {{ .Values.operator.jsonLog | ternary "true" "false" | quote }}
         - name: OPERATOR_AGENT_CONFIG

--- a/mirrord-operator/values.yaml
+++ b/mirrord-operator/values.yaml
@@ -22,6 +22,9 @@ operator:
   sqsSplitting: false
   # Has to be set to `true` in order to use the Kafka queue splitting feature.
   kafkaSplitting: false
+  # Has to be set to `true` in order to use the argocd application auto-sync pause feature.
+  applicationPauseAutoSync: false
+
   # imagePullSecrets:
   #   - name: value
   


### PR DESCRIPTION
add a clusterrole rule to allow applications integration for auto-sync pause feature

```yaml
- apiGroups:
  - argoproj.io
  resources:
  - applications
  verbs:
  - list
  - get
  - patch
```