### PR TITLE
Fix .Values scoping issue in namespaced-role.yaml

### DIFF
--- a/mirrord-operator/Chart.yaml
+++ b/mirrord-operator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.11.0
+version: 1.11.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/mirrord-operator/templates/namespaced-role.yaml
+++ b/mirrord-operator/templates/namespaced-role.yaml
@@ -6,8 +6,8 @@ metadata:
   namespace: {{.}}
   labels:
     {{- include "mirrord-operator.labels" $ | nindent 4 }}
-    {{- if index $ "Values.role" "mirrord-operator-user" "labels" }}
-          {{- toYaml (index $ "Values.role" "mirrord-operator-user" "labels") | nindent 4 }}
+    {{- if index $.Values.role "mirrord-operator-user" "labels" }}
+          {{- toYaml (index $.Values.role "mirrord-operator-user" "labels") | nindent 4 }}
     {{- end }}
 rules:
 {{- include "mirrord-operator.rules" . | nindent 0 }}

--- a/mirrord-operator/templates/namespaced-role.yaml
+++ b/mirrord-operator/templates/namespaced-role.yaml
@@ -6,8 +6,8 @@ metadata:
   namespace: {{.}}
   labels:
     {{- include "mirrord-operator.labels" $ | nindent 4 }}
-    {{- if index .Values.role "mirrord-operator-user" "labels" }}
-          {{- toYaml (index .Values.role "mirrord-operator-user" "labels") | nindent 4 }}
+    {{- if index $ "Values.role" "mirrord-operator-user" "labels" }}
+          {{- toYaml (index $ "Values.role" "mirrord-operator-user" "labels") | nindent 4 }}
     {{- end }}
 rules:
 {{- include "mirrord-operator.rules" . | nindent 0 }}

--- a/test_values/operator_rolenamespaces.yaml
+++ b/test_values/operator_rolenamespaces.yaml
@@ -1,0 +1,9 @@
+license:
+  file:
+    secret: mirrord-operator-license
+    data:
+      license.pem: "DOESN'TNEEDTOBOOTSOITCANBEINVALID"
+
+roleNamespaces:
+  - namespace1
+  - namespace2


### PR DESCRIPTION
### **Description**
This PR addresses a scoping issue in the `namespaced-role.yaml` Helm template, where `.Values` could not be evaluated due to the context being overridden inside a `range` loop. The error encountered during the Helm upgrade was:

```
template: mirrord-operator/templates/namespaced-role.yaml:9:24: executing “mirrord-operator/templates/namespaced-role.yaml” at <.Values.role>: can’t evaluate field Values in type interface {}
```

### **Root Cause**
The `range` loop changes the context (`.`) to the current item being iterated (a namespace in `roleNamespaces`). As a result, `.Values` could not be accessed directly.

### **Proposed Fix**
- Use `$` to explicitly refer to the top-level context for accessing `.Values` and for calling nested templates like `labels` and `rules`.
- Ensure consistent access to `.Values` throughout the template.

---

### **Changes Made**
- Updated `namespaced-role.yaml` to use `$` for referencing the top-level context.
- Preserved compatibility with existing `values.yaml` configurations.

---

### **References**
- Original issue: `.Values` scoping error during Helm upgrade.