### PR TITLE
fix license server on aws ebs can't write/access mount 

### DIFF
--- a/mirrord-license-server/Chart.yaml
+++ b/mirrord-license-server/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.4
+version: 1.0.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/mirrord-license-server/templates/deployment.yaml
+++ b/mirrord-license-server/templates/deployment.yaml
@@ -36,6 +36,8 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000
+        runAsGroup: 2000
+        fsGroup: 2000
         {{/* Allow low port using ip_unprivileged_port_start */}}
         {{- if lt (int .Values.server.port) 1024 -}}
         sysctls:


### PR DESCRIPTION
fix license server on aws ebs can't write/access mount because of wrong uid/mount