### PR TITLE
Add mirorrdprofile back

### DIFF
--- a/mirrord-license-server/Chart.yaml
+++ b/mirrord-license-server/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.7
+version: 1.0.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "3.111.0"
+appVersion: "3.113.0"

--- a/mirrord-license-server/Chart.yaml
+++ b/mirrord-license-server/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.8
+version: 1.0.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "3.112.0"
+appVersion: "3.111.0"

--- a/mirrord-operator/Chart.yaml
+++ b/mirrord-operator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.26.1
+version: 1.26.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/mirrord-operator/templates/crd.yaml
+++ b/mirrord-operator/templates/crd.yaml
@@ -1485,6 +1485,62 @@ spec:
         properties:
           spec:
             description: |-
+              This custom resource has been superseded by `MirrordClusterProfile` and should no longer be used. During the migration period, we support both this and the new `MirrordClusterProfile` custom resource definition.
+
+              Once users have migrated, we plan to re-introduce the kind `MirrordProfile` in future releases for namespaced mirrord profile.
+            properties:
+              featureAdjustments:
+                description: |-
+                  A list of adjustments to be made in the user's feature config.
+
+                  The adjustments are applied in order.
+                items:
+                  description: A single adjustment to the mirrord config's `feature` section.
+                  properties:
+                    change:
+                      description: The change to be made in the user's config.
+                      enum:
+                      - incoming-mirror
+                      - incoming-steal
+                      - incoming-off
+                      - dns-remote
+                      - dns-off
+                      - outgoing-remote
+                      - outgoing-off
+                      type: string
+                  required:
+                  - change
+                  type: object
+                type: array
+            required:
+            - featureAdjustments
+            type: object
+        required:
+        - spec
+        title: MirrordProfile
+        type: object
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: mirrordclusterprofiles.profiles.mirrord.metalbear.co
+spec:
+  group: profiles.mirrord.metalbear.co
+  names:
+    kind: MirrordClusterProfile
+    plural: mirrordclusterprofiles
+    singular: mirrordclusterprofile
+  scope: Cluster
+  versions:
+  - name: v1alpha
+    schema:
+      openAPIV3Schema:
+        description: Auto-generated derived type for MirrordClusterProfileSpec via `CustomResource`
+        properties:
+          spec:
+            description: |-
               Custom cluster-wide resource for storing a reusable mirrord config template.
 
               Can be selected from the user's mirrord config.
@@ -1521,7 +1577,7 @@ spec:
             type: object
         required:
         - spec
-        title: MirrordProfile
+        title: MirrordClusterProfile
         type: object
     served: true
     storage: true

--- a/mirrord-operator/templates/crd.yaml
+++ b/mirrord-operator/templates/crd.yaml
@@ -1469,19 +1469,19 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: mirrordclusterprofiles.profiles.mirrord.metalbear.co
+  name: mirrordprofiles.profiles.mirrord.metalbear.co
 spec:
   group: profiles.mirrord.metalbear.co
   names:
-    kind: MirrordClusterProfile
-    plural: mirrordclusterprofiles
-    singular: mirrordclusterprofile
+    kind: MirrordProfile
+    plural: mirrordprofiles
+    singular: mirrordprofile
   scope: Cluster
   versions:
   - name: v1alpha
     schema:
       openAPIV3Schema:
-        description: Auto-generated derived type for MirrordClusterProfileSpec via `CustomResource`
+        description: Auto-generated derived type for MirrordProfileSpec via `CustomResource`
         properties:
           spec:
             description: |-
@@ -1521,7 +1521,7 @@ spec:
             type: object
         required:
         - spec
-        title: MirrordClusterProfile
+        title: MirrordProfile
         type: object
     served: true
     storage: true


### PR DESCRIPTION
Add MirrordProfile back so it won't delete users' CRD and existing profile CR during `helm upgrade`.