### PR TITLE
Allow operator to also watch webhook confs.

### DIFF
--- a/mirrord-operator/templates/cluster-role.yaml
+++ b/mirrord-operator/templates/cluster-role.yaml
@@ -128,9 +128,10 @@ rules:
   resources:
     - mutatingwebhookconfigurations
   verbs:
+    - create
     - delete
     - deletecollection
-    - create
+    - watch
 {{- end }}
 {{- end }}
 {{- if .Values.operator.kafkaSplitting }}


### PR DESCRIPTION
we need it for waiting for the configuration to actually be created before restarting the target workload.