### PR TITLE
Make the repo more user friendly with docs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -138,6 +138,21 @@ jobs:
         if: failure()
         run: kubectl logs -n mirrord deployment/mirrord-license-server
 
+  towncrier_check:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install uv
+        uses: astral-sh/setup-uv@v2
+      - run: uv python install
+      - run: uv venv
+      - name: install towncrier
+        run: uv pip install towncrier==23.11.0
+      - name: verify newsfragment exist
+        run: uv run towncrier check
+
   ci-success:
       runs-on: ubuntu-latest
       name: ci-success
@@ -149,6 +164,7 @@ jobs:
           operator-install,
           operator-install-and-use,
           operator-install-with-license-server-and-use,
+          towncrier_check,
         ]
       steps:
         - name: CI succeeded
@@ -157,5 +173,6 @@ jobs:
           env:
             CI_SUCCESS: ${{ (needs.sanity.result == 'success') &&
               (needs.operator-install.result == 'success') &&
-              (needs.operator-install-and-use.result == 'success') }}
+              (needs.operator-install-and-use.result == 'success') &&
+              (needs.towncrier_check.result == 'success') }}
           run: echo $CI_SUCCESS && if [ "$CI_SUCCESS" == "true" ]; then echo "SUCCESS" && exit 0; else echo "FAILURE" && exit 1; fi

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ helm install -f values.yaml mirrord-operator metalbear/mirrord-operator
 
 ### Operator License
 
-#### 🔑 Team License
+#### 🧑‍💻 Team License
 
 Set the license key directly:
 
@@ -77,7 +77,7 @@ license:
   keyRef: "my-secret:OPERATOR_LICENSE_KEY"
 ```
 
-#### 🛡️ Enterprise License
+#### 🧑‍💼 Enterprise License
 
 Paste the `.pem` certificate:
 
@@ -162,7 +162,7 @@ operator:
 
 ### Feature Toggles
 
-#### ✅ SQS Splitting
+#### 👥 SQS Splitting
 
 Enable SQS message routing for shared queues:
 
@@ -173,7 +173,7 @@ operator:
 
 More info: [SQS Splitting Docs](https://metalbear.co/mirrord/docs/using-mirrord/queue-splitting/#sqs-splitting)
 
-#### ✅ Kafka Splitting
+#### 🪶 Kafka Splitting
 
 Enable topic-level session isolation for Kafka:
 
@@ -187,7 +187,7 @@ Learn about:
 - [Kafka setup](https://metalbear.co/mirrord/docs/using-mirrord/queue-splitting/#kafka-splitting)
 - [TTL behavior](https://github.com/metalbear-co/charts/tree/main/mirrord-operator#sqs-queue-splitting)
 
-#### ✅ Copy Target
+#### 📝 Copy Target
 
 Control agent image usage:
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## mirrord operator
 
-The [mirrod operator](https://metalbear.co/mirrord/docs/overview/teams/) is a component
+The [mirrord operator](https://metalbear.co/mirrord/docs/overview/teams/) is a component
 that runs in your Kubernetes cluster and manages the concurrent use of mirrord by multiple
 users in the organization. With the operator, users don't need Kubernetes API permissions
 (RBAC is managed through the operator); agents are reused so multiple agents don't

--- a/README.md
+++ b/README.md
@@ -59,8 +59,6 @@ helm install -f values.yaml mirrord-operator metalbear/mirrord-operator
 
 ## Advanced Configuration
 
-> You’ll need [mirrord for Teams](https://metalbear.co/mirrord/pricing/) to continue.
-
 ### Operator License
 
 #### 🔑 Team License
@@ -232,7 +230,5 @@ Configure this chart if you use a `.pem` license and want full control of your s
 
 ## Useful Links
 
-- 🌐 [mirrord Documentation](https://metalbear.co/mirrord/docs/)
-- 📦 [Helm Charts on GitHub](https://github.com/metalbear-co/charts)
+- 🌐 [mirrord Documentation](https://metalbear.co/mirrord/docs/overview/introduction/)
 - 💰 [mirrord Pricing](https://metalbear.co/mirrord/pricing/)
-- 📋 [cert-manager Installation](https://cert-manager.io/docs/installation/helm/)

--- a/README.md
+++ b/README.md
@@ -4,10 +4,8 @@
 
 The [mirrord operator](https://metalbear.co/mirrord/docs/overview/teams/) is a component
 that runs in your Kubernetes cluster and manages the concurrent use of mirrord by multiple
-users in the organization. With the operator, users don't need Kubernetes API permissions
-(RBAC is managed through the operator); agents are reused so multiple agents don't
-impersonate the same pod; and deployments can be impersonated so that traffic from all
-their pods is stolen/mirrored.
+users in the organization. For more details and a list of features of the mirrord Operator
+see [this](https://metalbear.co/mirrord/pricing/).
 
 - [mirrord-operator](./mirrord-operator)
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ servers. It can aggregate license metrics from multiple operators
 (useful if you’re running mirrord across multiple clusters) and provides visibility into
 seat usage across your organization.
 
+- The mirrord License Server is only supported in the mirrord Enterprise plan.
+
 - [mirrord-license-server](./mirrord-license-server)
 
 ## Quick Setup

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ operator:
 
 ---
 
-### mirrord-Agent Configuration
+### mirrord-agent Configuration
 
 Customize the mirrord-agent container:
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ seat usage across your organization.
 
 - [mirrord-license-server](./mirrord-license-server)
 
-## Quick setup
+## Quick Setup
 
 ```bash
 helm repo add metalbear https://metalbear-co.github.io/charts

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ curl https://raw.githubusercontent.com/metalbear-co/charts/main/mirrord-operator
 ```
 
 Open `values.yaml` and populate the `license` with either your license key, or with your
-license `.pem` file contents.
+license `.pem` certificate contents.
 
 Additionally, the mirrord Operator requires a certificate. You can either:
 * Set `certManager.enabled` to `false` and provide your own certificate in `tls.key`, `tls.crt`
@@ -43,7 +43,7 @@ Additionally, the mirrord Operator requires a certificate. You can either:
 Finally, install the chart:
 
 ```bash
-helm install -f values.yaml mirrord-operator metalbear/mirrord-operator 
+helm install -f values.yaml mirrord-operator metalbear/mirrord-operator
 ```
 
 ## Detailed setup
@@ -52,7 +52,7 @@ Some mirrord operator features come **disabled** by default, and some additional
 configuration might be needed to tailor the operator for your environment.
 
 In the following sections we'll help you in setting up `values.yaml` for both the mirrord
-operator and the mirrord license server (relevant only if you have a license `.pem` file
+operator and the mirrord license server (relevant only if you have a license `.pem` certificate
 and want to run the server on-premise).
 
 - Before proceeding, you'll need mirrord for Teams, you can find more information about
@@ -60,7 +60,61 @@ and want to run the server on-premise).
 
 ### mirrord operator
 
-#### Operator namespace and namespaced roles
+#### Operator license
+
+- Team license key
+
+If you're subscribed to mirrord for Teams for a Team license, then all you have to do is set the
+`license` field to use your key, either directly, or create a secret with the key `OPERATOR_LICENSE_KEY`,
+then use `license.keyRef` to reference it. You can find your license key in the
+[app.metalbear page](https://app.metalbear.co/).
+
+```yaml
+license:
+  key: "my-team-license-key"
+```
+
+Or with `keyRef.
+
+```yaml
+license:
+  keyRef: "secret-name:key-name"
+```
+
+- Enterprise license
+
+Enterprise users receive a `.pem` certificate that you can add directly to `license.data.license.pem`.
+
+```yaml
+license:
+  file:
+    data:
+      license.pem: |
+        -----BEGIN CERTIFICATE-----
+        your-certificate...
+        -----END CERTIFICATE-----
+```
+
+Or you can create a secret with the following format:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+    name: mirrord-operator-license-pem
+    namespace: mirrord
+stringData:
+    license.pem: LICENSE_CONTENT
+```
+
+Then reference it in the `license.pemRef` field.
+
+```yaml
+license:
+  pemRef: "mirrord-operator-license-pem:license.pem"
+```
+
+#### Operator namespace and user roles
 
 You can configure the kubernetes `namespace` that the operator will be deployed in. It also
 affects where the mirrord agent pod is spawned when using the
@@ -69,7 +123,11 @@ affects where the mirrord agent pod is spawned when using the
 - `createNamespace` is set to `true` by default, meaning that the `namespace`
   (default `mirrord`) will be created on chart install, if it's set to `false`, then you
   must create the `namespace`;
-- `roleNamespaces` can be set to create namespaced `role`s. (What is this? I had to create the namespace before being able to use it, so mention that.)
+
+If you want to limit which `namespace`s user's may use mirrord in, it can be accomplished
+with the `roleNamespaces` setting. Note that the `namespace`s must be created beforehand,
+this does **not** create them. We do not recommend doing it this way, instead prefer
+to have a role binding (or a cluster role binding) that references a cluster role.
 
 ```yaml
 namespace: mirrord
@@ -77,4 +135,156 @@ createNamespace: true
 roleNamespaces: []
 ```
 
+The operator uses the `mirrord-operator-user.labels` to manage and identify user prileveges
+and roles. You can configure this at a namespaced level, under `role`, or at a cluster
+level under `clusterRole`.
+They are used in RBAC to manage the access of a user to operator features.
+
+```yaml
+role:
+  mirrord-operator-user:
+    labels:
+      app.kubernetes.io/component: "debugging"
+      team: "platform"
+```
+
+- At a cluster level, there's also support for a _basic_ operator user, that can be used to
+  grant limited permissions (only the minimal things you must have on the cluster role).
+  Think of this as a minimally privileged access that a user may have, when using mirrord.
+
+```yaml
+clusterRole:
+  mirrord-operator-user-basic:
+    labels:
+      app.kubernetes.io/component: "debugging"
+      team: "basic"
+  mirrord-operator-user:
+    labels:
+      app.kubernetes.io/component: "debugging"
+      team: "platform"
+```
+
+#### General operator configuration
+
+The operator `image` is sourced by default from `ghcr.io/metalbear-co/operator`, but you can
+change that to your own repository.
+
+You can set `annotations` and `labels` to the operator pod, to enable things like
+[prometheus](https://prometheus.io/) for the operator. The operator may spawn mirrord-agent
+pods, but those pods have their own `annotations` and `labels` configuration.
+
+```yaml
+operator:
+  image: ghcr.io/metalbear-co/operator
+  podAnnotations:
+    prometheus.io/scrape: "true"
+  podLabels:
+    environment: staging
+```
+
+By default, `limits` is set to a value that should accomodate roughly 200 concurrent mirrord
+sessions.
+
+```yaml
+operator:
+  limits:
+    cpu: 200m
+    memory: 200Mi
+```
+
+If you have [prometheus](https://prometheus.io/) running in your cluster, you can enable
+the operator metrics endpoint (on `0.0.0.0:9000` by default) by changing `metrics` to `true`
+(it comes as `false` by default). It's possible to chage the address by setting the
+`OPERATOR_METRICS_ADR` environment variable in `extraEnv`.
+
+```yaml
+operator:
+  metrics: true
+  extraEnv:
+    OPERATOR_METRICS_ADDR: "0.0.0.0:9000"
+```
+
+- `extraEnv` may be used for more than just changing the prometheus address. It can be
+  especially useful when debugging the operator itself, or to change something in the operator
+  that hasn't been exposed by the chart.
+
+It's possible to disable the operator telemetries (only for Enterprise license) by changing
+the default `disableTelemetries` to `true`.
+
+```yaml
+operator:
+  disableTelemetries: false
+```
+
+The operator listens on port `443` by default, and this too can be changed.
+
+```yaml
+operator:
+  port: 443
+```
+
+Set `imagePullSecrets` if your operator or agent images are not public.
+
+```yaml
+operator:
+  imagePullSecrets:
+  - name: regcred
+```
+
+The operator logs can be shown in a terminal friendly way, or as JSON.
+
+```yaml
+operator:
+  jsonLog: false
+```
+
+#### Configuring operator features
+
+- [SQS splitting](https://metalbear.co/mirrord/docs/using-mirrord/queue-splitting/#sqs-splitting)
+
+Change the default `sqsSplitting` from `false` to `true`. You can get more details on
+[getting started with SQS splitting](https://metalbear.co/mirrord/docs/using-mirrord/queue-splitting/#getting-started-with-sqs-splitting).
+
+```yaml
+operator:
+  sqsSplitting: true
+```
+
+You can find more information on what's needed for the operator to work with SQS
+[here](https://github.com/metalbear-co/charts/tree/main/mirrord-operator#sqs-queue-splitting).
+
+- [Kafka splitting](https://metalbear.co/mirrord/docs/using-mirrord/queue-splitting/#kafka-splitting)
+
+Change the default `kafkaSplitting` from `false` to `true`. You can get more details on
+[getting started with Kafka splitting](https://metalbear.co/mirrord/docs/using-mirrord/queue-splitting/#getting-started-with-kafka-splitting).
+
+You can change the default TTL (in milliseconds) for idle Kafka splits with
+`idleKafkaSplitTtlMillis`.For any given topic, starting the first Kafka splitting session
+requires patching the target workload. Similarly, stopping the last Kafka splitting session
+requires another patch, that reverts the first one. If the target workload takes a long
+time to restart, it may be desirable to keep the Kafka splits alive longer, so that the next
+Kafka splitting session will not have to patch the workload again.
+It can be overridden per topic with the `spec.splitTtl` field in the
+`MirrordKafkaTopicsConsumer` custom resource.
+
+```yaml
+operator:
+  kafkaSplitting: true
+  idleKafkaSplitTtlMillis: 30000
+```
+
+- [Copy target](https://metalbear.co/mirrord/docs/using-mirrord/copy-target/)
+
+The operator creates a dummy container using the mirrord-agent image by default. Doing so
+ensures that it has a `sleep` binary available. If you want the operator to use the target's
+image, you can change `copyTarget.useAgentImage` to `false` and make sure it has the `sleep` binary.
+
+```yaml
+operator:
+  copyTarget:
+    useAgentImage: true
+```
+
 ### mirrord license server {#mirrord-license-server}
+
+[mirrord-license-server](./mirrord-license-server)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ their pods is stolen/mirrored.
 
 - [mirrord-operator](./mirrord-operator)
 
-## mirrord license server
+## mirrord License Server
 
 The [mirrord license server](https://metalbear.co/mirrord/docs/managing-mirrord/license-server/)
 enables you to manage your organization’s seats without sending any data to mirrord’s

--- a/README.md
+++ b/README.md
@@ -285,6 +285,40 @@ operator:
     useAgentImage: true
 ```
 
+#### Configuring the mirrord-agent
+
+The agent `image` is sourced by default from `ghcr.io/metalbear-co/agent`, but you can change that
+to your own repository.
+
+```yaml
+agent:
+  image: ghcr.io/metalbear-co/agent
+```
+
+You can set on which port the agent accepts connections from the operator with the `agent.port`
+config, by default a random port is assigned. These connections can be secured with TLS by setting
+`agent.tls` to `true`.
+
+```yaml
+agent:
+  port: 7777
+  tls: true
+```
+
+It's possible to change
+[mirrord-agent settings](https://metalbear.co/mirrord/docs/reference/configuration/#root-agent)
+that are not exposed by the chart with the `agent.extraConfig` config, these include (but are not
+limited by).
+
+```yaml
+agent:
+  extraConfig:
+    agent:
+      metrics: "0.0.0.0:9000
+      annotations: { prometheus.io/scrape: "true" }
+      log_level: "mirrrod=debug,warn"
+```
+
 ### mirrord license server {#mirrord-license-server}
 
 [mirrord-license-server](./mirrord-license-server)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Metalbear Helm Charts
 
-## mirrord operator
+## mirrord Operator
 
 The [mirrord operator](https://metalbear.co/mirrord/docs/overview/teams/) is a component
 that runs in your Kubernetes cluster and manages the concurrent use of mirrord by multiple

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Metalbear Helm Charts
+# MetalBear Helm Charts
 
 ## mirrord Operator
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ license:
 
 - Enterprise license
 
-Enterprise users receive a `.pem` certificate that you can add directly to `license.data.license.pem`.
+Enterprise users receive a `.pem` certificate that you can add directly to
+`license.data.license.pem`.
 
 ```yaml
 license:
@@ -91,8 +92,11 @@ license:
     data:
       license.pem: |
         -----BEGIN CERTIFICATE-----
-        your-certificate...
+        thecertificate
         -----END CERTIFICATE-----
+        -----BEGIN PRIVATE KEY-----
+        thekey
+        -----END PRIVATE KEY-----
 ```
 
 Or you can create a secret with the following format:

--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ agent:
     agent:
       metrics: "0.0.0.0:9000
       annotations: { prometheus.io/scrape: "true" }
-      log_level: "mirrrod=debug,warn"
+      log_level: "mirrord=debug,warn"
 ```
 
 ### mirrord license server {#mirrord-license-server}

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ servers. It can aggregate license metrics from multiple operators
 (useful if you’re running mirrord across multiple clusters) and provides visibility into
 seat usage across your organization.
 
-- The mirrord License Server is only supported in the mirrord Enterprise plan.
+> The mirrord License Server is only supported in the mirrord Enterprise plan.
 
 - [mirrord-license-server](./mirrord-license-server)
 
@@ -37,8 +37,8 @@ Open `values.yaml` and populate the `license` with either your license key, or w
 license `.pem` certificate contents.
 
 Additionally, the mirrord Operator requires a certificate. You can either:
-* Set `certManager.enabled` to `false` and provide your own certificate in `tls.key`, `tls.crt`
-* Set `certManager.enabled` to `true` and [install cert-manager](https://cert-manager.io/docs/installation/helm/) in your cluster.
+- Set `certManager.enabled` to `false` and provide your own certificate in `tls.key`, `tls.crt`
+- Set `certManager.enabled` to `true` and [install cert-manager](https://cert-manager.io/docs/installation/helm/) in your cluster.
 
 Finally, install the chart:
 
@@ -55,7 +55,7 @@ In the following sections we'll help you in setting up `values.yaml` for both th
 operator and the mirrord license server (relevant only if you have a license `.pem` certificate
 and want to run the server on-premise).
 
-- Before proceeding, you'll need mirrord for Teams, you can find more information about
+> Before proceeding, you'll need mirrord for Teams, you can find more information about
   acquiring it from our [metalbear.co pricing](https://metalbear.co/mirrord/pricing/) page.
 
 ### mirrord operator
@@ -124,9 +124,9 @@ You can configure the kubernetes `namespace` that the operator will be deployed 
 affects where the mirrord agent pod is spawned when using the
 [copy target feature](https://metalbear.co/mirrord/docs/using-mirrord/copy-target/).
 
-- `createNamespace` is set to `true` by default, meaning that the `namespace`
+> `createNamespace` is set to `true` by default, meaning that the `namespace`
   (default `mirrord`) will be created on chart install, if it's set to `false`, then you
-  must create the `namespace`;
+  must create the `namespace`.
 
 If you want to limit which `namespace`s user's may use mirrord in, it can be accomplished
 with the `roleNamespaces` setting. Note that the `namespace`s must be created beforehand,
@@ -152,7 +152,7 @@ role:
       team: "platform"
 ```
 
-- At a cluster level, there's also support for a _basic_ operator user, that can be used to
+> At a cluster level, there's also support for a _basic_ operator user, that can be used to
   grant limited permissions (only the minimal things you must have on the cluster role).
   Think of this as a minimally privileged access that a user may have, when using mirrord.
 
@@ -208,7 +208,7 @@ operator:
     OPERATOR_METRICS_ADDR: "0.0.0.0:9000"
 ```
 
-- `extraEnv` may be used for more than just changing the prometheus address. It can be
+> `extraEnv` may be used for more than just changing the prometheus address. It can be
   especially useful when debugging the operator itself, or to change something in the operator
   that hasn't been exposed by the chart.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,80 @@
 # Metalbear Helm Charts
 
-* [mirrord-license-server](./mirrord-license-server)
-* [mirrord-operator](./mirrord-operator)
+## mirrord operator
+
+The [mirrod operator](https://metalbear.co/mirrord/docs/overview/teams/) is a component
+that runs in your Kubernetes cluster and manages the concurrent use of mirrord by multiple
+users in the organization. With the operator, users don't need Kubernetes API permissions
+(RBAC is managed through the operator); agents are reused so multiple agents don't
+impersonate the same pod; and deployments can be impersonated so that traffic from all
+their pods is stolen/mirrored.
+
+- [mirrord-operator](./mirrord-operator)
+
+## mirrord license server
+
+The [mirrord license server](https://metalbear.co/mirrord/docs/managing-mirrord/license-server/)
+enables you to manage your organization’s seats without sending any data to mirrord’s
+servers. It can aggregate license metrics from multiple operators
+(useful if you’re running mirrord across multiple clusters) and provides visibility into
+seat usage across your organization.
+
+- [mirrord-license-server](./mirrord-license-server)
+
+## Quick setup
+
+```bash
+helm repo add metalbear https://metalbear-co.github.io/charts
+```
+
+Then download the accompanying `values.yaml`:
+
+```bash
+curl https://raw.githubusercontent.com/metalbear-co/charts/main/mirrord-operator/values.yaml --output values.yaml
+```
+
+Open `values.yaml` and populate the `license` with either your license key, or with your
+license `.pem` file contents.
+
+Additionally, the mirrord Operator requires a certificate. You can either:
+* Set `certManager.enabled` to `false` and provide your own certificate in `tls.key`, `tls.crt`
+* Set `certManager.enabled` to `true` and [install cert-manager](https://cert-manager.io/docs/installation/helm/) in your cluster.
+
+Finally, install the chart:
+
+```bash
+helm install -f values.yaml mirrord-operator metalbear/mirrord-operator 
+```
+
+## Detailed setup
+
+Some mirrord operator features come **disabled** by default, and some additional
+configuration might be needed to tailor the operator for your environment.
+
+In the following sections we'll help you in setting up `values.yaml` for both the mirrord
+operator and the mirrord license server (relevant only if you have a license `.pem` file
+and want to run the server on-premise).
+
+- Before proceeding, you'll need mirrord for Teams, you can find more information about
+  acquiring it from our [metalbear.co pricing](https://metalbear.co/mirrord/pricing/) page.
+
+### mirrord operator
+
+#### Operator namespace and namespaced roles
+
+You can configure the kubernetes `namespace` that the operator will be deployed in. It also
+affects where the mirrord agent pod is spawned when using the
+[copy target feature](https://metalbear.co/mirrord/docs/using-mirrord/copy-target/).
+
+- `createNamespace` is set to `true` by default, meaning that the `namespace`
+  (default `mirrord`) will be created on chart install, if it's set to `false`, then you
+  must create the `namespace`;
+- `roleNamespaces` can be set to create namespaced `role`s. (What is this? I had to create the namespace before being able to use it, so mention that.)
+
+```yaml
+namespace: mirrord
+createNamespace: true
+roleNamespaces: []
+```
+
+### mirrord license server {#mirrord-license-server}

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Finally, install the chart:
 helm install -f values.yaml mirrord-operator metalbear/mirrord-operator
 ```
 
-## Detailed setup
+## Advanced Configuration
 
 Some mirrord operator features come **disabled** by default, and some additional
 configuration might be needed to tailor the operator for your environment.

--- a/changelog.d/170.changed.md
+++ b/changelog.d/170.changed.md
@@ -1,0 +1,1 @@
+Improve readme.md with better docs for the charts.

--- a/changelog.d/changelog_template.jinja
+++ b/changelog.d/changelog_template.jinja
@@ -1,0 +1,15 @@
+{% if sections[""] %}
+{% for category, val in definitions.items() if category in sections[""] %}
+
+### {{ definitions[category]['name'] }}
+
+{% for text, values in sections[""][category].items() %}
+- {{ text }} {{ values|join(', ') }}
+{% endfor %}
+
+{% endfor %}
+{% else %}
+No significant changes.
+
+
+{% endif %}

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -1,0 +1,44 @@
+[tool.towncrier]
+directory = "changelog.d"
+filename = "CHANGELOG.md"
+start_string = "<!-- towncrier release notes start -->\n"
+underlines = ["", "", ""]
+template = "changelog.d/changelog_template.jinja"
+title_format = "## [{version}](https://github.com/metalbear-co/charts/tree/{version}) - {project_date}"
+issue_format = "[#{issue}](https://github.com/metalbear-co/charts/issues/{issue})"
+wrap = true
+
+[[tool.towncrier.type]]
+directory = "security"
+name = "Security"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "removed"
+name = "Removed"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "deprecated"
+name = "Deprecated"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "added"
+name = "Added"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "changed"
+name = "Changed"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "fixed"
+name = "Fixed"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "internal"
+name = "Internal"
+showcontent = true


### PR DESCRIPTION
- Issue: https://github.com/metalbear-co/charts/issues/170

Expanding some docs, borrowing some docs from the `values.yaml`, and linking stuff to our docs site.

Also added changelog to CI.

- Still a bit of a wip, since right now it contains almost nothing about the `license-server`, few configs missing from the operator.

> You're not seeing double, this is a non-fork-pr