### PR TITLE
Allows the user to set `labels` to the `operator`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repository contains Helm charts for deploying [mirrord](https://metalbear.c
 
 ## mirrord Operator
 
-The [mirrord Operator](https://metalbear.co/mirrord/docs/overview/teams/) is a Kubernetes component that facilitates the concurrent use of mirrord by multiple team members. 
+The [mirrord Operator](https://metalbear.co/mirrord/docs/overview/teams/) is a Kubernetes component that facilitates the concurrent use of mirrord by multiple team members.
 
 For full feature details, visit the [mirrord pricing page](https://metalbear.co/mirrord/pricing/).
 
@@ -143,8 +143,12 @@ operator:
   image: ghcr.io/metalbear-co/operator
   podAnnotations:
     prometheus.io/scrape: "true"
+  ## Applied only to pods.
   podLabels:
     environment: staging
+  ## Applied to ALL resources (Deployment, Service, etc).
+  labels:
+    team: platform
   limits:
     cpu: 200m
     memory: 200Mi

--- a/changelog.d/+218.added.md
+++ b/changelog.d/+218.added.md
@@ -1,0 +1,1 @@
+Allows the user to set `labels` to the `operator`.

--- a/mirrord-operator/templates/_helpers.tpl
+++ b/mirrord-operator/templates/_helpers.tpl
@@ -5,6 +5,9 @@ helm.sh/chart: {{ printf "%s-%s" $.Chart.Name $.Chart.Version | replace "+" "_" 
 app.kubernetes.io/instance: {{ $.Release.Name }}
 app.kubernetes.io/version: {{ $.Chart.AppVersion | quote }}
 app.kubernetes.io/managed-by: {{ $.Release.Service }}
+{{- if .Values.operator.labels }}
+{{- toYaml .Values.operator.labels | nindent 0 }}
+{{- end }}
 {{- end }}
 
 {{/* rules needed to use mirrord and can be namespaced*/}}

--- a/mirrord-operator/values.yaml
+++ b/mirrord-operator/values.yaml
@@ -31,6 +31,15 @@ operator:
   image: ghcr.io/metalbear-co/operator
   podAnnotations: {}
   podLabels: {}
+
+  ## Custom labels to be added to all Kubernetes resources created by this chart.
+  ## These labels will be applied to higher-level resources like Deployments, Services, etc.
+  ## For pod-specific labels, use operator.podLabels instead.
+  ## Example:
+  ## labels:
+  ##   team: platform
+  labels: {}
+
   jsonLog: false
   # Define additional environment variables for the operator.
   extraEnv: {}
@@ -45,7 +54,7 @@ operator:
 
   # imagePullSecrets:
   #   - name: value
-  
+
   ## stop using container args for agent config, as now you can just use agent.extraConfig
   ## also imagePullSecrets is re-used from operator.imagePullSecrets
   # containerArgs:
@@ -66,7 +75,7 @@ operator:
   ## Similarly, stopping the last Kafka splitting session requires another patch, that reverts the first one.
   ## If the target workload takes a long time to restart, it may be desirable to keep the Kafka splits alive longer,
   ## so that the next Kafka splitting session will not have to patch the workload again.
-  ## 
+  ##
   ## This value can be overridden per topic with the `spec.splitTtl` field in the `MirrordKafkaTopicsConsumer` custom resource.
   # idleKafkaSplitTtlMillis: 30000
 
@@ -110,7 +119,7 @@ operator:
     # to use the target's image, set this value to false and make sure it has sleep binary
     useAgentImage: true
 
-  ## The URL of the Jira webhook to enable integration with the mirrord for Jira app. 
+  ## The URL of the Jira webhook to enable integration with the mirrord for Jira app.
   ## If this is set, the operator will attempt to send session duration metrics to the Jira app
   ## every time a user session ends.
   # jiraWebhookUrl: "https://example.atlassian-dev.net/x1/random-hash"
@@ -118,7 +127,7 @@ operator:
 agent:
   ## example
   ##
-  ## image: 
+  ## image:
   ##   registry: "your-internal.registry.io/metalbear-co/agent"
   ##   tag: "latest"
   ##
@@ -126,7 +135,7 @@ agent:
   ##
   ## image: "your-internal.registry.io/metalbear-co/agent:latest"
   ##
-  # image: 
+  # image:
     # registry: "ghcr.io/metalbear-co/mirrord"
     # tag: "latest"
 
@@ -165,7 +174,7 @@ license:
   # licenseServer: http://mirrord-operator-license-server.mirrord.svc
 
   # For enterprise licenses the operator can allow usage for more than the max amount of seats.
-  # 
+  #
   # Set this value to `false` to disable this allowance to go over the max seats count.
   allowSeatOverages: true
 
@@ -190,7 +199,7 @@ tls:
   certManager:
     enabled: false
     createIssuer: true
-    
+
     issuer: mirrord-operator-issuer
     certificate: mirrord-operator-tls
 


### PR DESCRIPTION
- Issue: https://github.com/metalbear-co/private/issues/218

Changes where we add some default labels to operator stuff, allowing the user to set their own labels too.