### PR TITLE
License server can fetch license file from GSM, fixed docs and names

### DIFF
--- a/changelog.d/+license-server-gsm-fetch.added.md
+++ b/changelog.d/+license-server-gsm-fetch.added.md
@@ -1,0 +1,1 @@
+Added an option to fetch the license from Google Secret Manager (license-server).

--- a/mirrord-license-server/templates/deployment.yaml
+++ b/mirrord-license-server/templates/deployment.yaml
@@ -77,12 +77,14 @@ spec:
         - name: TLS_KEY_PATH
           value: /tls/tls.key
         {{- end }}
-        {{- if or .Values.license.file.data }}
+        {{- if .Values.license.file.data }}
         - name: LICENSE_PATH
           value: /license/license.pem
         {{- else if .Values.license.gsmRef }}
         - name: OPERATOR_LICENSE_GSM_REF
           value: {{ .Values.license.gsmRef }}
+        {{- else }}
+          {{- fail "Either .license.file.data or .license.gsmRef value is required" }}
         {{- end }}
         {{- if .Values.license.key  }}
         - name: LICENSE_KEY
@@ -92,7 +94,7 @@ spec:
         - secretRef:
             name: {{ .Values.license.keyRef }}
         {{- else }}
-          {{- required "Either keyRef, key value is required for license!" .Values.license.keyRef }}
+          {{- fail "Either .license.keyRef or .license.key value is required" }}
         {{- end }}
         image: {{ .Values.server.image }}:{{ or .Values.server.tag .Chart.AppVersion }}
         imagePullPolicy: IfNotPresent

--- a/mirrord-license-server/templates/deployment.yaml
+++ b/mirrord-license-server/templates/deployment.yaml
@@ -77,8 +77,13 @@ spec:
         - name: TLS_KEY_PATH
           value: /tls/tls.key
         {{- end }}
+        {{- if or .Values.license.file.data }}
         - name: LICENSE_PATH
           value: /license/license.pem
+        {{- else if .Values.license.gsmRef }}
+        - name: OPERATOR_LICENSE_GSM_REF
+          value: {{ .Values.license.gsmRef }}
+        {{- end }}
         {{- if .Values.license.key  }}
         - name: LICENSE_KEY
           value: {{ .Values.license.key }}
@@ -135,9 +140,11 @@ spec:
         secret:
           secretName: {{ .Values.tls.secret }}
       {{- end }}
+      {{- if .Values.license.file.data }}
       - name: license-volume
         secret:
           secretName: {{ .Values.license.file.secret }}
+      {{- end }}
       - name: data
         persistentVolumeClaim:
           claimName: mirrord-license-server-pvc

--- a/mirrord-license-server/templates/license.yaml
+++ b/mirrord-license-server/templates/license.yaml
@@ -10,5 +10,5 @@ stringData:
   {{- toYaml .Values.license.file.data | nindent 2 }}
 {{- end }}
 {{- /*
-don't create secret if using keyRef or pemRef
+don't create secret if using gsmRef
 */}}

--- a/mirrord-license-server/templates/service-account.yaml
+++ b/mirrord-license-server/templates/service-account.yaml
@@ -1,6 +1,10 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  {{- if .Values.sa.gcpSa }}
+  annotations:
+    iam.gke.io/gcp-service-account: {{ .Values.sa.gcpSa }}
+  {{- end }}
   labels:
     app: mirrord-license-server
     {{- include "mirrord-license-server.labels" . | nindent 4 }}

--- a/mirrord-license-server/values.yaml
+++ b/mirrord-license-server/values.yaml
@@ -50,6 +50,15 @@ server:
   port: 8080
 
 license:
+  ## ID of a secret from the Google Secrets Manager.
+  ##
+  ## If provided, the license server will fetch the license file from this secret.
+  ##
+  ## To access the secret, the license server will use Application Default Credentials.
+  ## The easiest way to provide credentials is by allowing the license server's
+  ## Kubernetes ServiceAccount to impersonate a GCP service account.
+  ## This can be done with `.sa.gcpSa` setting.
+  # gsmRef: "projects/PROJECT_ID/secrets/SECRET_NAME/versions/SECRET_VERSION"
   key: ""
   file:
     secret: mirrord-operator-license-server-license
@@ -79,6 +88,9 @@ pvc:
 
 sa:
   name: mirrord-operator-license-server
+
+  ## GCP service account to impersonate.
+  # gcpSa: <iam-sa-name>@<iam-sa-project-id>.iam.gserviceaccount.com
 
 tls:
   secret: mirrord-operator-license-server-tls

--- a/mirrord-operator/templates/service-account.yaml
+++ b/mirrord-operator/templates/service-account.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  {{- if or .Values.sa.roleArn .Values.sa.roleGke }}
+  {{- if or .Values.sa.roleArn .Values.sa.gcpSa }}
   annotations:
     {{- if .Values.sa.roleArn }}
     eks.amazonaws.com/role-arn: {{ .Values.sa.roleArn }}
     {{- end }}
-    {{- if .Values.sa.roleGke }}
-    iam.gke.io/gcp-service-account: {{ .Values.sa.roleGke }}
+    {{- if .Values.sa.gcpSa }}
+    iam.gke.io/gcp-service-account: {{ .Values.sa.gcpSa }}
     {{- end }}
   {{- end }}
   labels:

--- a/mirrord-operator/values.yaml
+++ b/mirrord-operator/values.yaml
@@ -175,7 +175,11 @@ license:
   ## ID of a secret from the Google Secrets Manager.
   ##
   ## If provided, the operator will fetch the license file from this secret.
-  ## The operator will use Application Default Credentials.
+  ##
+  ## To access the secret, the operator will use Application Default Credentials.
+  ## The easiest way to provide credentials is by allowing the operator's
+  ## Kubernetes ServiceAccount to impersonate a GCP service account.
+  ## This can be done with `.sa.gcpSa` setting.
   # gsmRef: "projects/PROJECT_ID/secrets/SECRET_NAME/versions/SECRET_VERSION"
   key: ""
   file:
@@ -202,10 +206,10 @@ service:
 sa:
   name: mirrord-operator
 
-  ## aws role arn to annotate for eks iam assumption
+  ## AWS role ARN to use for IAM role assumption.
   # roleArn: arn:aws:iam::111122223333:role/mirrord-operator-role
-  # gpc role to annotate for gke workload identity iam assumption
-  # roleGke: mirrord-operator@<project-id>.iam.gserviceaccount.com
+  ## GCP service account to impersonate.
+  # gcpSa: <iam-sa-name>@<iam-sa-project-id>.iam.gserviceaccount.com
 
 tls:
   secret: mirrord-operator-tls


### PR DESCRIPTION
Changed the docs and names to use vocab from https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity (this should make it more user friendly)