### PR TITLE
Add annotations and labels in mysql config example

### DIFF
--- a/changelog.d/+mysql-example.changed.md
+++ b/changelog.d/+mysql-example.changed.md
@@ -1,0 +1,1 @@
+Added labels and annotations to the mysql branch config example.

--- a/mirrord-operator/values.yaml
+++ b/mirrord-operator/values.yaml
@@ -165,6 +165,8 @@ operator:
     ##   imagePullSecrets:
     ##     - name: "mysql-registry-secret"
     ##   imagePullPolicy: "IfNotPresent"
+    ##   labels: { "role": "database" }
+    ##   annotations: { "db.branch/owner-team": "platform" }
     ##   volume:
     ##     name: "mysql-data"
     ##     emptyDir:

--- a/test_values/operator_mysql.yaml
+++ b/test_values/operator_mysql.yaml
@@ -1,0 +1,25 @@
+operator:
+  mysqlBranching: true
+  mysqlBranchConfig:
+    dbPod:
+      image:
+        registry: "mysql"
+      volume:
+        name: "mysql-beautiful-data"
+        emptyDir:
+          sizeLimit: "1Gi"
+      labels: { "role": "database" }
+      annotations: { "db.branch/owner-team": "platform" }
+      resources:
+        requests:
+          cpu: "500m"
+          memory: "512Mi"
+        limits:
+          cpu: "1"
+          memory: "1Gi"
+
+license:
+  file:
+    secret: mirrord-operator-license
+    data:
+      license.pem: "DOESN'TNEEDTOBOOTSOITCANBEINVALID"


### PR DESCRIPTION
It will end up looking like this for the branch pod:
```
Name:             mirrord-mysql-branch-db-pod-xcvnq
Namespace:        mysql-branching-test
Priority:         0
Service Account:  default
Node:             docker-desktop/192.168.65.3
Start Time:       Thu, 06 Nov 2025 09:43:02 -0500
Labels:           db-owner-name=server-echo-mysql-branch-ltwrt
                  db-owner-uid=ac764185-a4f1-4b1c-b17f-8a90ceffa7f2
                  role=database
Annotations:      db.branch/owner-team: platform
Status:           Running
...
```