### PR TITLE
improved docs for no pod timout

### DIFF
--- a/changelog.d/+no-pod-timeout-docs.changed.md
+++ b/changelog.d/+no-pod-timeout-docs.changed.md
@@ -1,0 +1,1 @@
+Improved docs for operator.noPodTargetsSessionTimeoutMillis value.

--- a/mirrord-operator/values.yaml
+++ b/mirrord-operator/values.yaml
@@ -89,7 +89,8 @@ operator:
   # maxSessionTimeSeconds: 3600
 
   ## Controls how long (in milliseconds) a session can live when there are no pods ready to be targeted.
-  # noPodTargetsSessionTimeoutMillis: 6000
+  ## When this value is not set when installing the chart, the default value of 60000 (60 seconds) is used.
+  # noPodTargetsSessionTimeoutMillis: 60000
 
   ## Default TTL (in milliseconds) for idle Kafka splits.
   ## For any given topic, starting the first Kafka splitting session requires patching the target workload.


### PR DESCRIPTION
- value was 6 instead of 60 seconds
- explicitly mention it's the default value