### PR TITLE
fail curl when mirrord binary isn't found (404)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -168,7 +168,7 @@ jobs:
           retry_wait_seconds: 1
           command: kubectl get mirrordoperators.operator.metalbear.co operator -o yaml
       - name: download latest mirrord binary
-        run: curl -LO https://github.com/metalbear-co/mirrord/releases/latest/download/mirrord_linux_x86_64 && chmod +x ./mirrord_linux_x86_64
+        run: curl --fail-with-body -LO https://github.com/metalbear-co/mirrord/releases/latest/download/mirrord_linux_x86_64 && chmod +x ./mirrord_linux_x86_64
       - name: run dummy mirrord session
         run: MIRRORD_OPERATOR_ENABLE=true MIRRORD_TELEMETRY=false ./mirrord_linux_x86_64 exec -- echo whatever
       - name: get operator logs
@@ -223,7 +223,7 @@ jobs:
           retry_wait_seconds: 1
           command: kubectl get mirrordoperators.operator.metalbear.co operator -o yaml
       - name: download latest mirrord binary
-        run: curl -LO https://github.com/metalbear-co/mirrord/releases/latest/download/mirrord_linux_x86_64 && chmod +x ./mirrord_linux_x86_64
+        run: curl --fail-with-body -LO https://github.com/metalbear-co/mirrord/releases/latest/download/mirrord_linux_x86_64 && chmod +x ./mirrord_linux_x86_64
       - name: run dummy mirrord session
         run: MIRRORD_OPERATOR_ENABLE=true MIRRORD_TELEMETRY=false ./mirrord_linux_x86_64 exec -- echo whatever
       - name: get operator logs

--- a/changelog.d/+curl-fail.internal.md
+++ b/changelog.d/+curl-fail.internal.md
@@ -1,0 +1,1 @@
+Fail when we fail to download the mirrord binary instead of downloading a "Not Found" response and trying to use it a mirrord binary.


### PR DESCRIPTION
With this change, when the mirrord binary isn't found (404), we get this indicative error:
https://github.com/metalbear-co/charts/actions/runs/19473074043/job/55725493848?pr=294
<img width="397" height="25" alt="image" src="https://github.com/user-attachments/assets/c0200cae-5b8e-440d-ba4c-12df86d635db" />

Instead of what happens right now, which is curl "successfully" downloads a file that contains the string `Not Found` and we then try to use it as a mirrord binary:
https://github.com/metalbear-co/charts/actions/runs/19468536490/job/55720177404?pr=292
<img width="429" height="31" alt="image" src="https://github.com/user-attachments/assets/bbf48d78-885b-4870-b5ea-de6b9bb7a546" />
