### PR TITLE
Add pods/proxy get|list|watch to the mirrord-operator ClusterRole.

### DIFF
--- a/mirrord-license-server/changelog.d/+tmp-dir.added.md
+++ b/mirrord-license-server/changelog.d/+tmp-dir.added.md
@@ -1,0 +1,1 @@
+Added an `emptyDir` volume which is mounted as the `/tmp` directory.

--- a/mirrord-license-server/templates/deployment.yaml
+++ b/mirrord-license-server/templates/deployment.yaml
@@ -136,6 +136,8 @@ spec:
         # needed for the license-server create sqlite database
         - mountPath: /opt/mirrord/data
           name: data
+        - mountPath: /tmp
+          name: tmp
       serviceAccountName: {{ .Values.sa.name }}
       volumes:
       {{- if or (index .Values.tls.data "tls.key") .Values.tls.certManager.enabled }}
@@ -152,3 +154,5 @@ spec:
       - name: data
         persistentVolumeClaim:
           claimName: mirrord-license-server-pvc
+      - emptyDir: {}
+        name: tmp


### PR DESCRIPTION
- Issue: https://github.com/metalbear-co/operator/issues/1014
- Related PRs:
  - https://github.com/metalbear-co/mirrord/pull/3885
  - https://github.com/metalbear-co/operator/pull/1213

To hit the agent pod metrics, we need to make a request to `/api/v1/namespaces/[mirrord]/pods/[mirrord-agent]:{metrics_port}/proxy/metrics`, and thus we need this permission.