### PR TITLE
app-version-3.138.0

### DIFF
--- a/mirrord-license-server/CHANGELOG.md
+++ b/mirrord-license-server/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [mirrord-operator-license-server-1.4.17](https://github.com/metalbear-co/charts/tree/mirrord-operator-license-server-1.4.17) - 2026-02-02
+
+- Bumped `appVersion`.
+
 ## [mirrord-operator-license-server-1.4.16](https://github.com/metalbear-co/charts/tree/mirrord-operator-license-server-1.4.16) - 2026-01-24
 
 ### Added

--- a/mirrord-license-server/Chart.yaml
+++ b/mirrord-license-server/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.4.16
+version: 1.4.17
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "3.137.0"
+appVersion: "3.138.0"

--- a/mirrord-license-server/changelog.d/changelog_template.jinja
+++ b/mirrord-license-server/changelog.d/changelog_template.jinja
@@ -7,7 +7,6 @@
 
 {% endfor %}
 {% else %}
-Bumped `appVersion`.
-
+- Bumped `appVersion`.
 
 {% endif %}

--- a/mirrord-operator/CHANGELOG.md
+++ b/mirrord-operator/CHANGELOG.md
@@ -1,7 +1,9 @@
-## [mirrord-operator-1.45.0](https://github.com/metalbear-co/charts/tree/mirrord-operator-1.45.0) - 2026-01-29
+## [mirrord-operator-1.46.0](https://github.com/metalbear-co/charts/tree/mirrord-operator-1.46.0) - 2026-02-02
 
 ### Added
 - Values can now be set for exporting OTel logs and traces from the operator.
+
+## [mirrord-operator-1.45.0](https://github.com/metalbear-co/charts/tree/mirrord-operator-1.45.0) - 2026-01-29
 
 ### Fixed
 - Fixed issues with helm v4.

--- a/mirrord-operator/Chart.yaml
+++ b/mirrord-operator/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.45.0
+version: 1.46.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "3.137.0"
+appVersion: "3.138.0"

--- a/mirrord-operator/changelog.d/changelog_template.jinja
+++ b/mirrord-operator/changelog.d/changelog_template.jinja
@@ -7,7 +7,6 @@
 
 {% endfor %}
 {% else %}
-Bumped `appVersion`.
-
+- Bumped `appVersion`.
 
 {% endif %}


### PR DESCRIPTION
🎲 Update to operator version 3.138.0
-> (operator chart minor bump, license server patch bump)
🎲 Fix misleading OTel changelog entry from last chart release
🎲 Fix extra newline in jinja templates