### PR TITLE
Fix incorrect env var name

### DIFF
--- a/mirrord-operator/changelog.d/+otel-env.fixed.md
+++ b/mirrord-operator/changelog.d/+otel-env.fixed.md
@@ -1,0 +1,1 @@
+Removed typo from the env var set by `operator.otelLogLevel` to `OTLP_RUST_LOG`.

--- a/mirrord-operator/templates/deployment.yaml
+++ b/mirrord-operator/templates/deployment.yaml
@@ -60,7 +60,7 @@ spec:
         - name: RUST_LOG
           value: {{ .Values.operator.logLevel }}
         {{- if .Values.operator.otelLogLevel }}
-        - name: OTEL_RUST_LOG
+        - name: OTLP_RUST_LOG
           value: {{ .Values.operator.otelLogLevel }}
         {{- end }}
         {{- if .Values.operator.otelLogExportUrl }}


### PR DESCRIPTION
`OTEL_RUST_LOG` -> `OTLP_RUST_LOG` to match the operator