### PR TITLE
operator/crd: define the new `expiresAt` field in `PreviewSessionSpec`

### DIFF
--- a/mirrord-operator/changelog.d/+preview-env-show-ttl.added.md
+++ b/mirrord-operator/changelog.d/+preview-env-show-ttl.added.md
@@ -1,0 +1,1 @@
+The `mirrord preview status` command will now show the remaining TTL of each preview environment session.

--- a/mirrord-operator/templates/crd.yaml
+++ b/mirrord-operator/templates/crd.yaml
@@ -3325,6 +3325,14 @@ spec:
             description: Status of a preview session resource.
             nullable: true
             properties:
+              expiresAt:
+                description: |-
+                  Timestamp when the session's TTL expires.
+
+                  Set when the session enters the `Ready` phase. Computed as `now + ttl_secs` at the moment the operator starts the TTL countdown. `None` during earlier phases or when running against an older operator that does not set this field.
+                format: date-time
+                nullable: true
+                type: string
               failureMessage:
                 description: |-
                   Human-readable description of why the session failed.


### PR DESCRIPTION
- Related PRs:
  - https://github.com/metalbear-co/mirrord/pull/3969
  - https://github.com/metalbear-co/operator/pull/1302